### PR TITLE
fix infinite loop when reading corrupted files

### DIFF
--- a/src/io/processor.rs
+++ b/src/io/processor.rs
@@ -117,6 +117,9 @@ impl HevcProcessor {
             self.parser.get_offsets(&self.chunk, &mut self.offsets);
 
             if self.offsets.is_empty() {
+                if read_bytes == 0 {
+                    break;
+                }
                 continue;
             }
 


### PR DESCRIPTION
hdr10plus_tool will hang when parsing corrupted files as such:

```
[evan@arch hdr10plus_tool]$ hexyl x.hevc
 00000000  41 41 41 41 41 41 0a                               AAAAAA_
[evan@arch hdr10plus_tool]$ cargo run -- --verify extract --input x.hevc -o /dev/null
// hangs forever
```

with this patch, the same input correctly terminates processing:
```
[evan@arch hdr10plus_tool]$ cargo run -- --verify extract --input x.hevc -o /dev/null
Error: File doesn't contain dynamic metadata
```